### PR TITLE
Allow custom headers to be added to HTTP response

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -99,6 +99,12 @@ export class Server {
      */
     httpServer(secure: boolean) {
         this.express = express();
+        this.express.use(function(req, res, next) {
+            for(var header in this.options.headers) {
+                res.setHeader(header, this.options.headers[header]);
+            }
+            next();
+        });
 
         if (secure) {
             var httpServer = https.createServer(this.options, this.express);


### PR DESCRIPTION
This code will allow custom HTTP headers to be specified in the laravel-echo-server.json configuration so that they are added to every HTTP response. This is needed for PCI-DSS compliance. For example this would allow the following required headers for PCI-DSS to be set:

    "headers" : {
        "X-XSS-Protection": "1;mode=block",
        "X-Content-Type-Options": "nosniff",
        "Strict-Transport-Security": "max-age=31536000"
    },